### PR TITLE
Wildcard adress as an hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ And `npm run build`
 
 You can also `npm run build -- -w` to watch, or `npm run build -- -h` to hot-reload.
 
+You can also specify an `hostname` for hot reload `npm run build -- -h -hh 127.0.0.1`, you can use `--hh` or `--hot-hostname`. Default value for hostname is `0.0.0.0`.
+
 Simple bundle splitting
 ----
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ And `npm run build`
 
 You can also `npm run build -- -w` to watch, or `npm run build -- -h` to hot-reload.
 
-You can also specify an `hostname` for hot reload `npm run build -- -h -hh 127.0.0.1`, you can use `--hh` or `--hot-hostname`. Default value for hostname is `0.0.0.0`.
+You can also specify `hostname` for the hot reload server: `npm run build -- -h 127.0.0.1`. If you supply `-h` (or `--hot`) with no value, the default hostname of `0.0.0.0` is used.
 
 Simple bundle splitting
 ----

--- a/bin/monobrow.js
+++ b/bin/monobrow.js
@@ -17,6 +17,7 @@ if (typeof config.watch === 'undefined') {
 
 if (typeof config.hot === 'undefined') {
   config.hot = argv.h || argv.hot
+  config.hot_hostname = argv['hh'] || argv['hot-hostname'] || '0.0.0.0'
 }
 
 if (typeof config.inc === 'undefined') {

--- a/bin/monobrow.js
+++ b/bin/monobrow.js
@@ -16,8 +16,9 @@ if (typeof config.watch === 'undefined') {
 }
 
 if (typeof config.hot === 'undefined') {
-  config.hot = argv.h || argv.hot
-  config.hot_hostname = argv['hh'] || argv['hot-hostname'] || '0.0.0.0'
+  const hotVal = argv.h || argv.hot
+  config.hot = Boolean(hotVal)
+  config.hotHostname = typeof hotVal === 'string' ? hotVal : '0.0.0.0'
 }
 
 if (typeof config.inc === 'undefined') {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function (opts) {
 
   if (opts.hot) {
     b.plugin(hmr, {
-      hostname: opts.hot_hostname
+      hostname: opts.hotHostname
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ module.exports = function (opts) {
   }
 
   if (opts.hot) {
-    b.plugin(hmr)
+    b.plugin(hmr, {
+      hostname: '0.0.0.0'
+    })
   }
 
   // normalize setup packs

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function (opts) {
 
   if (opts.hot) {
     b.plugin(hmr, {
-      hostname: '0.0.0.0'
+      hostname: opts.hot_hostname
     })
   }
 


### PR DESCRIPTION
The problem is with docker `127.0.0.1` on mac (not tested anywhere else) it is not exposed to the host machine, and on top of that we need to use the wildcard address as na hostname for hot reload module.

This is a fast solution I think that this would work on any docker machine and I added `0.0.0.0` as an default value, but if there would be a problem with that I also added host name option to monobrow so you can specify any hostname

```
npm run build -- -h --hot-host 127.0.0.1
// short
npm run build -- -h --hh 127.0.0.1
```